### PR TITLE
fix: Issue where script is not invoked if installed as npm modules

### DIFF
--- a/src/utils.mjs
+++ b/src/utils.mjs
@@ -23,6 +23,10 @@ export function info(msg) {
   console.log(chalk.whiteBright.bold(msg));
 }
 
+export function error(msg) {
+  console.log(chalk.redBright.bold(msg));
+}
+
 export async function doesDistFolderExist() {
   try {
     const stat = await fsPromise.stat(`./${BUILD_DIR}`);


### PR DESCRIPTION
- This is due to how NPM handles installed programs. Their use of symlinks causes a false negative in the condition that is meant to check if the script is being executed by the shell or imported to another file.
- Since imports were only for tests, I used env variables to make the distinction instead